### PR TITLE
Fixed bugs in importing PBR PLY's and PLY's without normals

### DIFF
--- a/src/parsers/parsers.cpp
+++ b/src/parsers/parsers.cpp
@@ -511,24 +511,36 @@ namespace parsers
         file.close();
     }
 
-    void loadPlyFile(std::string plyFileLocation, std::vector<utils::GaussianDataSSBO>& gaussians)
+    void loadPlyFile(std::string plyFileLocation, std::vector<utils::GaussianDataSSBO>& gaussians, bool& hasPbr)
     {
         try {
-            happly::PLYData plyIn(plyFileLocation);
+            happly::PLYData plyIn(plyFileLocation, true);
             std::vector<float> vertex_x = plyIn.getElement("vertex").getProperty<float>("x");
             std::vector<float> vertex_y = plyIn.getElement("vertex").getProperty<float>("y");
             std::vector<float> vertex_z = plyIn.getElement("vertex").getProperty<float>("z");
-        
-            std::vector<float> vertex_nx = plyIn.getElement("vertex").getProperty<float>("nx");
-            std::vector<float> vertex_ny = plyIn.getElement("vertex").getProperty<float>("ny");
-            std::vector<float> vertex_nz = plyIn.getElement("vertex").getProperty<float>("nz");
+
+            std::vector<float> vertex_nx;
+            std::vector<float> vertex_ny;
+            std::vector<float> vertex_nz;
+            if (plyIn.getElement("vertex").hasProperty("nx"))
+				vertex_nx = plyIn.getElement("vertex").getProperty<float>("nx");
+            if (plyIn.getElement("vertex").hasProperty("ny"))
+				vertex_ny = plyIn.getElement("vertex").getProperty<float>("ny");
+            if (plyIn.getElement("vertex").hasProperty("nz"))
+				vertex_nz = plyIn.getElement("vertex").getProperty<float>("nz");
 
             std::vector<float> vertex_f_dc_0 = plyIn.getElement("vertex").getProperty<float>("f_dc_0");
             std::vector<float> vertex_f_dc_1 = plyIn.getElement("vertex").getProperty<float>("f_dc_1");
             std::vector<float> vertex_f_dc_2 = plyIn.getElement("vertex").getProperty<float>("f_dc_2");
 
             //TODO: skipping SHs for now
-        
+
+            std::vector<float> vertex_metallic, vertex_roughness;
+            if (plyIn.getElement("vertex").hasProperty("metallicFactor"))
+	            vertex_metallic = plyIn.getElement("vertex").getProperty<float>("metallicFactor");
+            if (plyIn.getElement("vertex").hasProperty("roughnessFactor"))
+                vertex_roughness = plyIn.getElement("vertex").getProperty<float>("roughnessFactor");
+
             std::vector<float> vertex_opacity = plyIn.getElement("vertex").getProperty<float>("opacity");
         
             std::vector<float> vertex_scale_0 = plyIn.getElement("vertex").getProperty<float>("scale_0");
@@ -542,8 +554,7 @@ namespace parsers
 
             size_t numVertices = vertex_x.size();
             if (vertex_y.size() != numVertices || vertex_z.size() != numVertices ||
-                vertex_nx.size() != numVertices || vertex_ny.size() != numVertices ||
-                vertex_nz.size() != numVertices || vertex_f_dc_0.size() != numVertices ||
+                vertex_f_dc_0.size() != numVertices ||
                 vertex_f_dc_1.size() != numVertices || vertex_f_dc_2.size() != numVertices ||
                 vertex_opacity.size() != numVertices || vertex_scale_0.size() != numVertices ||
                 vertex_scale_1.size() != numVertices || vertex_scale_2.size() != numVertices ||
@@ -551,6 +562,10 @@ namespace parsers
                 vertex_rot_2.size() != numVertices || vertex_rot_3.size() != numVertices) {
                 throw std::runtime_error("Inconsistent vertex property sizes in PLY file.");
             }
+
+            hasPbr = vertex_metallic.size() == numVertices && vertex_roughness.size() == numVertices &&
+                     vertex_nx.size() == numVertices && vertex_ny.size() == numVertices &&
+                     vertex_nz.size() == numVertices;
 
             gaussians.clear();
             gaussians.reserve(numVertices);
@@ -575,10 +590,18 @@ namespace parsers
                 gaussian.scale.z = glm::exp(vertex_scale_2[i]);
                 gaussian.scale.w = 1.0f;
 
-                gaussian.normal.x = vertex_nx[i];
-                gaussian.normal.y = vertex_ny[i];
-                gaussian.normal.z = vertex_nz[i];
-                gaussian.normal.w = 0.0f;
+                if (hasPbr)
+                {
+                    gaussian.normal.x = vertex_nx[i];
+                    gaussian.normal.y = vertex_ny[i];
+                    gaussian.normal.z = vertex_nz[i];
+                    gaussian.normal.w = 0.0f;
+                }
+                else
+                {
+	                gaussian.normal = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+                }
+
                 glm::quat rot = glm::quat(vertex_rot_0[i], vertex_rot_1[i], vertex_rot_2[i], vertex_rot_3[i]);
                 rot = glm::normalize(rot);
                 gaussian.rotation.x = rot.w;
@@ -586,7 +609,14 @@ namespace parsers
                 gaussian.rotation.z = rot.y;
                 gaussian.rotation.w = rot.z;
 
-                gaussian.pbr = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+                if (hasPbr)
+                {
+	                gaussian.pbr = glm::vec4(vertex_metallic[i], vertex_roughness[i], 0.0f, 0.0f);
+                }
+                else
+                {
+					gaussian.pbr = glm::vec4(0.0f, 0.0f, 0.0f, 0.0f);
+                }
 
                 gaussians.push_back(gaussian);
             }

--- a/src/parsers/parsers.hpp
+++ b/src/parsers/parsers.hpp
@@ -19,7 +19,7 @@ namespace parsers
 
 	void writeBinaryPlyStandardFormat(const std::string& filename, const std::vector<utils::GaussianDataSSBO>& gaussians, float scaleMultiplier);
 
-	void loadPlyFile(std::string plyFileLocation, std::vector<utils::GaussianDataSSBO>& gaussians);
+	void loadPlyFile(std::string plyFileLocation, std::vector<utils::GaussianDataSSBO>& gaussians, bool& hasPbr);
 
 	void savePlyVector(std::string outputFileLocation, std::vector<utils::GaussianDataSSBO> gaussians_3D_list, unsigned int format, float scaleMultiplier);
 

--- a/src/renderer/renderPasses/GaussiansPrepass.cpp
+++ b/src/renderer/renderPasses/GaussiansPrepass.cpp
@@ -23,6 +23,7 @@ void GaussiansPrepass::execute(RenderContext& renderContext)
     glUtils::setUniform2f(computeShaderGaussianPrepassProgramID,     "u_resolution", renderContext.rendererResolution);
     glUtils::setUniform1i(computeShaderGaussianPrepassProgramID,     "u_renderMode", renderContext.renderMode);
     glUtils::setUniform1ui(computeShaderGaussianPrepassProgramID,    "u_format", renderContext.format);
+    glUtils::setUniform1ui(computeShaderGaussianPrepassProgramID,    "u_plyHasPbr", renderContext.plyHasPbr ? 1u : 0u);
     glUtils::setUniformMat4(computeShaderGaussianPrepassProgramID,   "u_modelToWorld", renderContext.modelMat);
     glUtils::setUniform1i(computeShaderGaussianPrepassProgramID,     "u_gaussianCount", renderContext.numberOfGaussians);
     glUtils::setUniform2f(computeShaderGaussianPrepassProgramID,     "u_nearFar", glm::vec2(renderContext.nearPlane, renderContext.farPlane));

--- a/src/renderer/renderPasses/RenderContext.hpp
+++ b/src/renderer/renderPasses/RenderContext.hpp
@@ -63,6 +63,7 @@ struct RenderContext {
     int normalizedUvSpaceHeight;
     unsigned int resolutionTarget; 
     unsigned int format; //0: from mesh2splat, 1: classic .ply 3dgs, 2: compressedPBR
+    bool plyHasPbr = false; // if format == 1 (loaded ply file), does ply support pbr rendering
 
     // Resources
     GLuint vao;

--- a/src/shaders/rendering/gaussianSplattingPrepassCS.glsl
+++ b/src/shaders/rendering/gaussianSplattingPrepassCS.glsl
@@ -35,6 +35,7 @@ uniform uint u_depthTestMesh;
 
 uniform int u_renderMode;
 uniform uint u_format;
+uniform uint u_plyHasPbr;
 uniform int u_gaussianCount;
 
 layout(std430, binding = 0) readonly buffer GaussianBuffer {
@@ -113,7 +114,7 @@ void main() {
 	float computedDepth = computeExponentialDepth(-gaussian_vs.z, u_nearFar);
 	
 
-	if (u_format == 0 || u_format == 3)
+	if (u_format == 0 || (u_format == 1 && u_plyHasPbr != 0) || u_format == 3)
 	{
 		vec3 normalWs = (transpose(inverse(u_modelToWorld)) * vec4(gaussian.normal.xyz, 1.0f)).xyz;
 		computedNormal_Ws = vec4(encodeNormal(normalWs), gaussian.color.a); //remember to decode this when using in the gbuffer

--- a/src/utils/SceneManager.cpp
+++ b/src/utils/SceneManager.cpp
@@ -36,7 +36,7 @@ bool SceneManager::loadModel(const std::string& filePath, const std::string& par
 
 bool SceneManager::loadPly(const std::string& filePath) {
     try {
-        parsers::loadPlyFile(filePath, renderContext.readGaussians);
+        parsers::loadPlyFile(filePath, renderContext.readGaussians, renderContext.plyHasPbr);
         return true;
     }
     catch (const std::exception& e)


### PR DESCRIPTION
This PR just fixes a couple of bugs in loading PLY files:
- Loading a ply file that didn't contain normals was fatal, even though they are not used for rendering in this mode. It now gracefully handles when the ply file doesn't contain normals.
- Ply importer now checks for metalness/roughness and imports those correctly if found.
- If the ply file does contain normals and supports PBR rendering, it now declares so to the renderer so the splat prepass will use the normals from the ply file instead of calculating its own.

Overall, it is now possible to import a mesh, convert it to splats, export the splats with PBR properties, and **re-import the exported ply file** and get a consistent appearance (previously lit rendering was broken).

This is an awesome project and I'm glad it has been made public!