### PR TITLE
Added inverse sigmoid encoding when exporting opacity

### DIFF
--- a/src/parsers/parsers.cpp
+++ b/src/parsers/parsers.cpp
@@ -296,7 +296,8 @@ namespace parsers
             //-----------------------------------------------------------------
 
             //Opacity
-            file.write(reinterpret_cast<const char*>(&gaussian.color.a), sizeof(gaussian.color.a));
+            float opacity = utils::invSigmoid(gaussian.color.a);
+            file.write(reinterpret_cast<const char*>(&opacity), sizeof(opacity));
             
             gaussian.scale.x = std::log(gaussian.scale.x * scaleMultiplier);
             gaussian.scale.y = std::log(gaussian.scale.y * scaleMultiplier);
@@ -490,7 +491,8 @@ namespace parsers
             }
 
             // Opacity
-            file.write(reinterpret_cast<const char*>(&gaussian.color.a), sizeof(gaussian.color.a));
+            float opacity = utils::invSigmoid(gaussian.color.a);
+            file.write(reinterpret_cast<const char*>(&opacity), sizeof(opacity));
 
             gaussian.scale.x = std::log(gaussian.scale.x * scaleMultiplier);
             gaussian.scale.y = std::log(gaussian.scale.y * scaleMultiplier);

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -267,6 +267,7 @@ namespace utils
     bool shouldSkip(const GaussianDataSSBO& g);
 
     inline float sigmoid(float opacity) { return 1.0 / (1.0 + std::exp(-opacity)); };
+    inline float invSigmoid(float alpha) { alpha = std::clamp(alpha, 0.0f, 1.0f); return -std::log((1.0f / (alpha + 1e-8f)) - 1.0f); }
 
     std::string formatWithCommas(int value);
 


### PR DESCRIPTION
Applying inverse of sigmoid function to alpha when exporting ply files to conform to usual conventions for ply files.

I chose not to do this when writing compressed PBR ply files, as I don't think it would be suitable for a uint8 format. I would suggest that potentially compressed PBR ply files could declare the property to be `alpha` instead of `opacity`, which would be more fitting to meaning of the data and in line with the `red`, `green`, and `blue` properties.

I chose an implementation of `invSigmoid` such that `sigmoid(invSigmoid(1)) = 1` and any infinities are avoided. This does mean that `sigmoid(invSigmoid(0))=9.999997e-09`, however it shouldn't be the case that splats will be exported with 0 opacity.

Thanks again for the great repo!