### PR TITLE
Add Linux Support and Fix Windows Build

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -68,7 +68,7 @@ if (WIN32)
         ${GLEW_DIR}/lib/Release/x64/glew32s.lib 
         opengl32)
 else()
-    target_link_libraries(Mesh2Splat glfw glew GL) #todo
+    target_link_libraries(Mesh2Splat glfw GLEW GL X11 Xrandr Xinerama Xcursor Xi Xxf86vm pthread dl) #todo
 endif()
 
 set_target_properties(Mesh2Splat PROPERTIES 

--- a/README.md
+++ b/README.md
@@ -109,6 +109,37 @@ To build **Mesh2Splat**, follow the following steps:
 
    > **Tip**: Use the release build if you only need the final executable in optimized (Release) mode.
 
+## Build Instructions (Linux)
+
+### Prerequisites
+
+Install dependencies:
+
+```bash
+sudo apt install build-essential cmake pkg-config git \
+    libfreeimage-dev libglew-dev libglfw3-dev libgl1-mesa-dev \
+    libxinerama-dev libxcursor-dev libxi-dev libxxf86vm-dev
+```
+
+### Build Steps
+
+1. Create and enter the build directory:
+   ```bash
+   mkdir build && cd build
+   ```
+
+2. Configure and build:
+   ```bash
+   cmake ..
+   cmake --build . -j16
+   ```
+
+3. Run the executable located in the `build` directory.
+
+<br>
+
+   > **Tip**: Use `cmake .. -DCMAKE_BUILD_TYPE=Release` if you only need the final executable in optimized (Release) mode.
+
 
 ## Limitations
 - Volumetric Data such as foliage, grass, hair, clouds, etc. has not being targeted and will probably not be converted correctly if using primitives different from triangles.<br>

--- a/src/imGuiUi/ImGuiUI.cpp
+++ b/src/imGuiUi/ImGuiUI.cpp
@@ -3,7 +3,7 @@
 //        Copyright (c) 2025 Electronic Arts Inc. All rights reserved.       //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "ImGuiUI.hpp"
+#include "ImGuiUi.hpp"
 
 ImGuiUI::ImGuiUI(float defaultGaussianStd, float defaultMesh2SPlatQuality)
     : resolutionIndex(0),

--- a/src/imGuiUi/ImGuiUI.cpp
+++ b/src/imGuiUi/ImGuiUI.cpp
@@ -118,7 +118,7 @@ void ImGuiUI::renderFileSelectorWindow()
     {
         if (ImGuiFileDialog::Instance()->IsOk()) {
             std::string chosenFolder = ImGuiFileDialog::Instance()->GetCurrentPath();
-            destinationFilePathFolder = chosenFolder + "\\";
+            destinationFilePathFolder = chosenFolder;
         }
 
         // Close the dialog

--- a/src/imGuiUi/ImGuiUi.hpp
+++ b/src/imGuiUi/ImGuiUi.hpp
@@ -110,7 +110,7 @@ public:
     void markBatchItemDone(const std::string& path);  // Processing -> Done
     void markBatchItemFailed(const std::string& path, const std::string& err);
     void cancelBatch();     
-    const std::vector<ImGuiUI::BatchItem>& ImGuiUI::getBatchItems() const;
+    const std::vector<ImGuiUI::BatchItem>& getBatchItems() const;
 
 private:
     int resolutionIndex = 0;

--- a/src/renderer/guiRendererConcreteMediator.cpp
+++ b/src/renderer/guiRendererConcreteMediator.cpp
@@ -3,7 +3,7 @@
 //        Copyright (c) 2025 Electronic Arts Inc. All rights reserved.       //
 ///////////////////////////////////////////////////////////////////////////////
 
-#include "GuiRendererConcreteMediator.hpp"
+#include "guiRendererConcreteMediator.hpp"
 
 void GuiRendererConcreteMediator::notify(EventType event)
 {

--- a/src/renderer/guiRendererConcreteMediator.hpp
+++ b/src/renderer/guiRendererConcreteMediator.hpp
@@ -4,8 +4,8 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#include "Mediator.hpp"
-#include "Renderer.hpp"
+#include "mediator.hpp"
+#include "renderer.hpp"
 #include "imGuiUi/ImGuiUi.hpp"
 
 class GuiRendererConcreteMediator : public IMediator {

--- a/src/renderer/renderer.hpp
+++ b/src/renderer/renderer.hpp
@@ -5,7 +5,7 @@
 
 #pragma once
 #include "utils/utils.hpp"
-#include "ioHandler.hpp"
+#include "IoHandler.hpp"
 #include "imGuiUi/ImGuiUi.hpp"
 #include "parsers/parsers.hpp"
 #include "utils/glUtils.hpp"

--- a/src/utils/glUtils.cpp
+++ b/src/utils/glUtils.cpp
@@ -4,7 +4,7 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #include "glUtils.hpp"
-#include "utils/shaderRegistry.hpp"
+#include "utils/ShaderRegistry.hpp"
 
 namespace glUtils 
 {

--- a/src/utils/glUtils.hpp
+++ b/src/utils/glUtils.hpp
@@ -98,7 +98,7 @@ namespace glUtils
     std::string resolveIncludes(const std::string& source, const fs::path& baseDir);
     std::string readShaderFile(const char* filePath);
 
-    namespace fs = std::experimental::filesystem;
+    namespace fs = std::filesystem;
 
     struct ShaderFileEditingInfo {
         fs::file_time_type lastWriteTime;

--- a/src/utils/utils.cpp
+++ b/src/utils/utils.cpp
@@ -3,6 +3,10 @@
 //        Copyright (c) 2025 Electronic Arts Inc. All rights reserved.       //
 ///////////////////////////////////////////////////////////////////////////////
 
+#ifndef _WIN32
+#include <unistd.h>
+#include <limits.h>
+#endif
 #include "utils.hpp"
 
 namespace utils
@@ -328,7 +332,7 @@ namespace utils
 
             //rgba_normal_info = glm::vec3(srgb_to_linear_float(rgba_normal_info.x), srgb_to_linear_float(rgba_normal_info.y), srgb_to_linear_float(rgba_normal_info.z));
         
-            if (!isnan(interpolatedTangent.x) && !isnan(interpolatedTangent.y) && !isnan(interpolatedTangent.z) && !isnan(interpolatedTangent.w))
+            if (!std::isnan(interpolatedTangent.x) && !std::isnan(interpolatedTangent.y) && !std::isnan(interpolatedTangent.z) && !std::isnan(interpolatedTangent.w))
             {
                 glm::vec3 tangentXYZ(interpolatedTangent);
                 glm::vec3 retrievedNormal = glm::normalize(glm::normalize(glm::vec3(rgba_normal_info) * 2.0f - 1.0f) * glm::vec3(material.normalScale, material.normalScale, 1.0f)); //https://registry.khronos.org/glTF/specs/2.0/glTF-2.0.html#_material_normaltextureinfo_scale
@@ -452,13 +456,23 @@ namespace utils
     }
 
     std::string getExecutablePath() {
+#ifdef _WIN32
         char buffer[MAX_PATH];
         GetModuleFileNameA(nullptr, buffer, MAX_PATH);
         return std::string(buffer);
+#else
+        char buffer[PATH_MAX];
+        ssize_t len = readlink("/proc/self/exe", buffer, sizeof(buffer) - 1);
+        if (len != -1) {
+            buffer[len] = '\0';
+            return std::string(buffer);
+        }
+        return "";
+#endif
     }
 
     std::string getExecutableDir() {
-        std::experimental::filesystem::path exePath(getExecutablePath());
+        fs::path exePath(getExecutablePath());
         return exePath.parent_path().string();
     }
 

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -29,10 +29,7 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
-#ifndef _WIN32
 #include <filesystem>
-#define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
-#endif
 #define EMPTY_TEXTURE "empty_texture"
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/string_cast.hpp>
@@ -73,11 +70,7 @@ static void CheckOpenGLError(const char* stmt, const char* fname, int line)
     #define GL_CHECK(stmt) stmt
 #endif
 
-#ifdef _WIN32
-namespace fs = std::experimental::filesystem;
-#else
 namespace fs = std::filesystem;
-#endif
 
 namespace utils
 {

--- a/src/utils/utils.hpp
+++ b/src/utils/utils.hpp
@@ -4,9 +4,11 @@
 ///////////////////////////////////////////////////////////////////////////////
 
 #pragma once
-#define _CRTDBG_MAP_ALLOC  
-#include <stdlib.h>  
-#include <crtdbg.h>  
+#ifdef _WIN32
+#define _CRTDBG_MAP_ALLOC
+#include <stdlib.h>
+#include <crtdbg.h>
+#endif
 
 #include <string>
 #include <vector>
@@ -27,8 +29,10 @@
 #include <GL/glew.h>
 #include <GLFW/glfw3.h>
 
+#ifndef _WIN32
+#include <filesystem>
 #define _SILENCE_EXPERIMENTAL_FILESYSTEM_DEPRECATION_WARNING
-#include <experimental/filesystem>
+#endif
 #define EMPTY_TEXTURE "empty_texture"
 #define GLM_ENABLE_EXPERIMENTAL
 #include <glm/gtx/string_cast.hpp>
@@ -38,6 +42,7 @@
 #include "imgui_impl_glfw.h"
 #include "imgui_impl_opengl3.h"
 
+#ifdef _WIN32
 #ifndef WIN32_LEAN_AND_MEAN
 #define WIN32_LEAN_AND_MEAN
 #endif
@@ -46,6 +51,7 @@
 #define NOMINMAX
 #endif
 #include <windows.h>
+#endif
 
 
 static void CheckOpenGLError(const char* stmt, const char* fname, int line)
@@ -67,7 +73,11 @@ static void CheckOpenGLError(const char* stmt, const char* fname, int line)
     #define GL_CHECK(stmt) stmt
 #endif
 
+#ifdef _WIN32
 namespace fs = std::experimental::filesystem;
+#else
+namespace fs = std::filesystem;
+#endif
 
 namespace utils
 {

--- a/thirdParty/imguizmo/ImGuizmo.cpp
+++ b/thirdParty/imguizmo/ImGuizmo.cpp
@@ -29,7 +29,7 @@
 #endif
 #include "imgui.h"
 #include "imgui_internal.h"
-#include "ImGuizmo.hpp"
+#include "Imguizmo.hpp"
 
 #if defined(_MSC_VER) || defined(__MINGW32__)
 #include <malloc.h>


### PR DESCRIPTION
### Summary
This PR adds Linux platform support and fixes the Windows build issues introduced during the cross-platform modifications.

### Changes

#### 1. Add Linux support (`edc38d2`)
- Updated `CMakeLists.txt` for Linux platform linking
- Added platform conditional compilation (`#ifdef _WIN32`) across multiple source files
- Modified `utils.cpp` and `utils.hpp` to add Linux path handling support
- Files modified:
  - `CMakeLists.txt`
  - `src/imGuiUi/ImGuiUI.cpp`
  - `src/imGuiUi/ImGuiUi.hpp`
  - `src/renderer/guiRendererConcreteMediator.cpp`
  - `src/renderer/guiRendererConcreteMediator.hpp`
  - `src/renderer/renderer.hpp`
  - `src/utils/glUtils.cpp`
  - `src/utils/glUtils.hpp`
  - `src/utils/utils.cpp`
  - `src/utils/utils.hpp`
  - `thirdParty/imguizmo/ImGuizmo.cpp`

#### 2. Linux: fix save path; add readme (`8493ddf`)
- Fixed save path issue on Linux (removed hardcoded backslash)
- Added Linux build instructions to `README.md`
- Files modified:
  - `README.md`
  - `src/imGuiUi/ImGuiUI.cpp`

#### 3. fix for windows build <filesystem> (`9051365`)
- Fixed Windows build by unifying `std::experimental::filesystem` to standard `std::filesystem`
- Removed conditional compilation since the project requires C++17, all platforms should use standard `std::filesystem`
- Files modified:
  - `src/utils/utils.hpp`

### Stats
- 11 files changed
- 40 insertions(+), 16 deletions(-)

### Testing
- ✅ Windows (VS2026): Build passed, GLB to PLY conversion tested
- ✅ Linux (GCC): Build passed, GLB to PLY conversion tested