### PR TITLE
Bug in batched mode + minor memory issue

### DIFF
--- a/src/renderer/guiRendererConcreteMediator.cpp
+++ b/src/renderer/guiRendererConcreteMediator.cpp
@@ -243,6 +243,7 @@ void GuiRendererConcreteMediator::startBatchJob(ImGuiUI::BatchItem* job, ImGuiUI
         renderer.getSceneManager().loadModel(job->path, job->parent);
         renderer.gaussianBufferFromSize(ui.getResolutionTarget() * ui.getResolutionTarget());
         renderer.setViewportResolutionForConversion(ui.getResolutionTarget());
+        renderer.setStdDevFromImGui(ui.getGaussianStd());
         renderer.enableRenderPass(conversionPassName);
         batchSubstate = BatchSubstate::Converting;
     } else {

--- a/src/utils/glUtils.cpp
+++ b/src/utils/glUtils.cpp
@@ -675,7 +675,6 @@ namespace glUtils
 
     void fillGaussianBufferSsbo(GLuint& gaussianBuffer, std::vector<utils::GaussianDataSSBO>& gaussians)
     {
-        glGenBuffers(1, &gaussianBuffer);
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, gaussianBuffer);
         //TODO: I will categorize this hardcoding issue of the number of output float4 params from the SSBO as: ISSUE6
         GLsizeiptr bufferSize = gaussians.size() * sizeof(glm::vec4) * 6;
@@ -685,7 +684,6 @@ namespace glUtils
 
     void fillGaussianBufferSsbo(GLuint& gaussianBuffer, unsigned int size)
     {
-        glGenBuffers(1, &gaussianBuffer);
         glBindBuffer(GL_SHADER_STORAGE_BUFFER, gaussianBuffer);
         //TODO: I will categorize this hardcoding issue of the number of output float4 params from the SSBO as: ISSUE6
         GLsizeiptr bufferSize = size * sizeof(glm::vec4) * 6;


### PR DESCRIPTION
One small batch mode fix for std dev was not being passed to batch jobs.

Batch convert was leaking ~96MB of GPU memory per model. `fillGaussianBufferSsbo` called glGenBuffers on every invocation instead of reusing the existing buffer.